### PR TITLE
Починил рассылку

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -450,7 +450,7 @@ class Errors(ErrorRoute):
     """Обработка непредвиденных ошибок"""
 
     def __init__(self):
-        super().__init__(filter=(lambda: True), handler=self.handle)
+        super().__init__(filter=(lambda *_: True), handler=self.handle)
 
     async def handle(self, update):
         await update.message.answer_sticker(stickers.MAINTAINCE_STICKER)

--- a/app/mailing.py
+++ b/app/mailing.py
@@ -3,6 +3,8 @@
 Каждые 15 минут происходит рассылка всем её подписчикам
 """
 
+from aiogram.exceptions import TelegramForbiddenError
+
 from app import templates
 from app.logger import logger
 
@@ -14,23 +16,32 @@ async def mailing(bot, db, weather, mailing_times):
     данным временем, и каждому отправляет прогноз погоды
     """
     async for mailing_time in mailing_times:
-        await send_mailing(bot, db, weather, mailing_time.time())
+        await send_mailings(bot, db, weather, mailing_time.time())
 
 
-async def send_mailing(bot, db, weather, mailing_time):
+async def send_mailings(bot, db, weather, mailing_time):
     """Отправляем рассылку пользователям с данным временем"""
     forecast = await weather.current()
     message_text = templates.MAILING_MESSAGE.format(forecast.format())
     sticker = forecast.sticker()
     subscribers = await db.of_time(mailing_time)
-
     for subscriber in subscribers:
         user_id = subscriber.id
-        await bot.send_sticker(user_id, sticker)
-        message = await bot.send_message(user_id, message_text)
-        await unpin_all_and_pin_message(bot, message)
+        try:
+            await send_mailing(bot, user_id, message_text, sticker)
+            logger.info(f"Пользователь {user_id} получил ежедневный прогноз")
+        except TelegramForbiddenError:
+            await db.delete(user_id)
+            logger.info(
+                f"Пользователь {user_id} удалён из рассылки из-за блока бота"
+            )
 
-        logger.info(f"Пользователь {user_id} получил ежедневный прогноз")
+
+async def send_mailing(bot, user_id, message_text, sticker):
+    """Отправляем рассылку пользователю"""
+    await bot.send_sticker(user_id, sticker)
+    message = await bot.send_message(user_id, message_text)
+    await unpin_all_and_pin_message(bot, message)
 
 
 async def unpin_all_and_pin_message(bot, message):


### PR DESCRIPTION
Closes #2 

Помимо этого убрал:

- Баг БД подписчиков

В #29 изменил `db.of_time()`, но не добавил структуру `Subscriber`, потому выдавало список кортежей. Исправлено + завести ишьюс на тест.

- Баг фильтра ошибок

В #20 передал `lambda: True` как dummy-фильтр для хендлера ошибок. Не учёл, что она должна принимать аргумент события ошибки, потому сама выдавала ошибку. Исправлено.