### PR TITLE
Починил кеш в CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v3
         id: cache
         with:
-          path: ~/.cache/pip
+          path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v3
         id: cache
         with:
-          path: ~/.cache/pip
+          path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Прошлый кеш не работал, попробуем так. Украл у [FastAPI](https://github.com/tiangolo/fastapi/blob/f7e3559bd5997f831fb9b02bef9c767a50facbc3/.github/workflows/test.yml)