### PR TITLE
Передаю время в шаблоны

### DIFF
--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -284,9 +284,7 @@ class MailingInfo(MessageRoute):
         try:
             sub = await self.db.find(user_id)
             time = sub.mailing_time
-            await message.answer(
-                templates.USER_IN_MAILING.format(time.hour, time.minute)
-            )
+            await message.answer(templates.USER_IN_MAILING.format(time))
         except UserNotFound:
             await message.answer(templates.USER_NOT_IN_MAILING)
 
@@ -354,9 +352,7 @@ class SetMailingMinute(CallbackRoute):
 
         await state.clear()
         await call.message.delete()  # удаляем клавитуру выбора минуты расылки
-        await call.message.answer(
-            templates.USER_SUBSCRIBED.format(time.hour, time.minute)
-        )
+        await call.message.answer(templates.USER_SUBSCRIBED.format(time))
         logger.info("Пользователь {} внесён в рассылку", user_id)
 
 
@@ -426,7 +422,7 @@ class ChangeMailingMinute(CallbackRoute):
         await state.clear()
         await call.message.delete()
         await call.message.answer(
-            templates.USER_CHANGED_MAILING_TIME.format(time.hour, time.minute),
+            templates.USER_CHANGED_MAILING_TIME.format(time),
         )
         logger.info("Пользователь {} изменил время рассылки", user_id)
 

--- a/app/templates.py
+++ b/app/templates.py
@@ -34,7 +34,7 @@ INFO = (
 
 USER_IN_MAILING = (
     "Вы зарегистрированы в подписке\n"
-    "Ваше время - {}:{:02}\n\n"
+    "Ваше время - {:%-H:%M}\n\n"
     "Поменять время - /change_time_mailing\n"
     "Отказаться от подписки - /cancel_mailing"
 )
@@ -44,8 +44,8 @@ USER_NOT_IN_MAILING = (
     "Вы можете подписаться на неё по команде /subscribe_to_mailing"
 )
 
-USER_SUBSCRIBED = "Вы подписались на рассылку по времени {}:{:02}"
-USER_CHANGED_MAILING_TIME = "Вы изменили время рассылки на {}:{:02}"
+USER_SUBSCRIBED = "Вы подписались на рассылку по времени {:%-H:%M}"
+USER_CHANGED_MAILING_TIME = "Вы изменили время рассылки на {:%-H:%M}"
 
 WEATHER = (
     "{forecast.weather_type.description}\n\n"


### PR DESCRIPTION
Теперь не надо разбивать время на часы/минуты, а можно передавать напрямую. Помимо красивости кода это позволило тоньше настраивать форматирование.